### PR TITLE
Additional logging

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,9 +1,10 @@
 const
     { ConsoleReporter } = require('@serenity-js/console-reporter'),
-    { ArtifactArchiver } = require('@serenity-js/core'),
+    { ArtifactArchiver, StreamReporter } = require('@serenity-js/core'),
     { Photographer, TakePhotosOfInteractions } = require('@serenity-js/protractor'),
     { SerenityBDDReporter } = require('@serenity-js/serenity-bdd'),
-    isCI = require('is-ci');
+    isCI = require('is-ci'),
+    fs = require('fs');
 
 exports.config = {
     baseUrl: 'https://juliemr.github.io/',
@@ -36,6 +37,7 @@ exports.config = {
             Photographer.whoWill(TakePhotosOfInteractions),     // slower execution, more comprehensive reports
             // Photographer.whoWill(TakePhotosOfFailures),      // fast execution, screenshots only when tests fail
             new SerenityBDDReporter(),
+            new StreamReporter(fs.createWriteStream(`./out-${ + new Date() }.log`))
         ]
     },
 


### PR DESCRIPTION
I can't reproduce the issue described in https://github.com/protractor-cucumber-framework/protractor-cucumber-framework/issues/243
But, if the error mentions that an async operation hasn't been completed, we'll need to know which one it was.

This PR adds additional logging of the internal Serenity/JS events. Since I can't reproduce the issue, could you please reproduce it and share the event log produced by Serenity/JS when the issue occurs?

Thanks,
Jan